### PR TITLE
Add summary page

### DIFF
--- a/index.html
+++ b/index.html
@@ -263,7 +263,21 @@
             width: 120px;
             color: var(--accent-color-1);
         }
-        
+
+        /* Simple summary link */
+        #simple-summary-link {
+            position: fixed;
+            bottom: 10px;
+            right: 10px;
+            font-size: 0.8rem;
+            z-index: 1100;
+        }
+
+        #simple-summary-link a {
+            color: var(--accent-color-1);
+            text-decoration: none;
+        }
+
         /* Responsive design */
         @media (max-width: 768px) {
             #loading-screen, #terminal {
@@ -816,5 +830,6 @@ For technical support, contact system administrator.`;
             displayLoadingItems();
         };
     </script>
+    <div id="simple-summary-link"><a href="summary.html">Plain summary page</a></div>
 </body>
 </html>

--- a/summary.html
+++ b/summary.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>KSK432 - Summary</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <nav id="navbar">
+    <ul>
+      <li><a class="menu-link" href="index.html">Home</a></li>
+      <li><a class="menu-link" href="works.html">Works</a></li>
+      <li><a class="menu-link active" href="summary.html">Summary</a></li>
+    </ul>
+  </nav>
+
+  <main class="container">
+    <section>
+      <h1>Profile</h1>
+      <p><strong>Name:</strong> Kosuke Shimizu</p>
+      <p><strong>Affiliation:</strong> University of Tsukuba</p>
+      <p><strong>Laboratories:</strong> Artificial Intelligence Laboratory, Kansei Design Lee Laboratory, Abe Laboratory</p>
+      <p><strong>Specialization:</strong> Human Computer Interaction, Computer-Mediated Communication, Virtual Reality</p>
+    </section>
+
+    <section>
+      <h1>Active Projects</h1>
+      <ul>
+        <li><strong>Insulin Device Projects</strong> – Data analysis and visualization for medical devices.</li>
+        <li><strong>Quantum Interface</strong> – Experimental interface design utilizing quantum interaction.</li>
+        <li><strong>Autonomous Systems</strong> – Self-regulating systems with adaptive learning capabilities.</li>
+      </ul>
+    </section>
+
+    <section>
+      <h1>Recent Publications</h1>
+      <ul>
+        <li>Emotion Overflow: An Interactive System to Represent Emotion in Fluid Dynamics (INTERACTION 2025)</li>
+        <li>Emotion Overflow: an Interactive System to Represent Emotion with Fluid (UIST 2024)</li>
+        <li>MoodGroove: テキストと身体動作による対話型音楽生成・編集システム (WISS 2024)</li>
+        <li>大和歌VR Recorder (VR学会大会 2024)</li>
+        <li>Effects of Binaural Audio on English Vocabulary Learning (ICCE 2022)</li>
+      </ul>
+    </section>
+
+    <section>
+      <h1>Contact</h1>
+      <p>For technical support, contact the system administrator.</p>
+    </section>
+  </main>
+
+  <footer>
+    <p>&copy; 2025 ksk432. All Rights Reserved.</p>
+  </footer>
+</body>
+</html>

--- a/works.html
+++ b/works.html
@@ -11,6 +11,7 @@
     <ul>
       <li><a class="menu-link" href="index.html">Home</a></li>
       <li><a class="menu-link active" href="works.html">Works</a></li>
+      <li><a class="menu-link" href="summary.html">Summary</a></li>
     </ul>
   </nav>
 


### PR DESCRIPTION
## Summary
- add `summary.html` page to summarize profile, projects, and publications
- link to the new page from `index.html` and `works.html`
- provide floating link on the terminal page

## Testing
- `tidy -qe summary.html`
- `tidy -qe works.html`
- `tidy -qe index.html`

------
https://chatgpt.com/codex/tasks/task_e_684534f52c8c8330a935111160319ce6