### PR TITLE
Fix syntax error in terminal command handler

### DIFF
--- a/index.html
+++ b/index.html
@@ -725,7 +725,7 @@ NOTE: This information is classified. Unauthorized access will be logged.`
                     displayContent(directory);
                 }
             } else {
-                addOutput("SYSTEM", `Directory not found: ${dir}", true);
+                addOutput("SYSTEM", `Directory not found: ${dir}`, true);
             }
         }
         


### PR DESCRIPTION
## Summary
- fix unclosed template literal in `index.html`

## Testing
- `node -c script_extracted.js`

------
https://chatgpt.com/codex/tasks/task_e_68453628849483308f90e583138e198a