### PR TITLE
Improve ls functionality to show directory contents

### DIFF
--- a/index.html
+++ b/index.html
@@ -342,6 +342,7 @@ System ready for operation.`
             },
             profile: {
                 title: "Profile",
+                subdirs: ['skills'],
                 content: `# PROFILE
                 
 NAME: Kosuke Shimizu
@@ -556,6 +557,10 @@ NOTE: This information is classified. Unauthorized access will be logged.`
         }
         
         // Terminal functionality
+        const rootDirs = ['home', 'profile', 'projects', 'publications', 'artwork', 'blog', 'misc', 'grades'];
+        const subDirMap = {
+            profile: ['skills']
+        };
         let currentDirectory = "~";
         let commandHistory = [];
         let historyIndex = -1;
@@ -612,7 +617,7 @@ NOTE: This information is classified. Unauthorized access will be logged.`
                     const command = terminalInput.value.trim();
                     if (command.startsWith('cd ')) {
                         const partial = command.substring(3).toLowerCase();
-                        const directories = ['home', 'profile', 'projects', 'publications', 'artwork', 'blog', 'misc', 'grades'];
+                        const directories = [...rootDirs, 'skills'];
                         
                         const matches = directories.filter(dir => dir.toLowerCase().startsWith(partial));
                         if (matches.length === 1) {
@@ -685,7 +690,7 @@ NOTE: This information is classified. Unauthorized access will be logged.`
                     break;
                 default:
                     // Check if command is a direct directory name
-                    if (['home', 'profile', 'projects', 'publications', 'artwork', 'blog', 'misc', 'grades'].includes(cmd)) {
+                    if ([...rootDirs, 'skills'].includes(cmd)) {
                         displayContent(cmd);
                     } else {
                         addOutput("SYSTEM", `Command not recognized: ${command}`, true);
@@ -701,18 +706,33 @@ NOTE: This information is classified. Unauthorized access will be logged.`
             });
             
             helpOutput += `\nDirectories can also be accessed directly by typing their name.`;
-            helpOutput += `\nNote: Only root directories exist. Use 'cd ..' before changing between them.`;
+            helpOutput += `\nUse 'ls' inside a directory to view its contents. Use 'cd ..' to return to the root.`;
             
             addOutput("SYSTEM", helpOutput, true);
         }
         
         function listDirectories() {
-            const dirs = ['home', 'profile', 'projects', 'publications', 'artwork', 'blog', 'misc', 'grades'];
-            let output = 'Available directories:\n\n';
-            dirs.forEach(dir => {
-                output += `${dir}    `;
-            });
-            addOutput("SYSTEM", output, true);
+            if (currentDirectory === '~') {
+                let output = 'Available directories:\n\n';
+                rootDirs.forEach(dir => {
+                    output += `${dir}    `;
+                });
+                addOutput("SYSTEM", output, true);
+            } else {
+                const section = currentDirectory.replace('~/', '').split('/').pop();
+                const parent = currentDirectory.replace('~/', '').split('/')[0];
+                const subdirs = content[section]?.subdirs || subDirMap[parent];
+
+                if (subdirs && currentDirectory.endsWith(parent)) {
+                    let output = 'Available directories:\n\n';
+                    subdirs.forEach(dir => {
+                        output += `${dir}    `;
+                    });
+                    addOutput("SYSTEM", output, true);
+                } else {
+                    displayContent(section);
+                }
+            }
         }
         
         function changeDirectory(dir) {
@@ -720,7 +740,6 @@ NOTE: This information is classified. Unauthorized access will be logged.`
                 addOutput("SYSTEM", "Usage: cd [directory]", true);
                 return;
             }
-
             const directory = dir.toLowerCase();
 
             if (directory === '..') {
@@ -728,7 +747,9 @@ NOTE: This information is classified. Unauthorized access will be logged.`
                     addOutput("SYSTEM", "Already at root.", true);
                     return;
                 }
-                currentDirectory = '~';
+                const parts = currentDirectory.split('/');
+                parts.pop();
+                currentDirectory = parts.join('/');
                 document.getElementById('current-path').textContent = currentDirectory;
                 return;
             }
@@ -739,20 +760,28 @@ NOTE: This information is classified. Unauthorized access will be logged.`
                 return;
             }
 
-            if (currentDirectory !== '~') {
-                addOutput("SYSTEM", "Use 'cd ..' to go up before changing directories.", true);
-                return;
-            }
-
-            const validDirs = ['home', 'profile', 'projects', 'publications', 'artwork', 'blog', 'misc', 'grades'];
-
-            if (validDirs.includes(directory)) {
-                currentDirectory = `~/${directory}`;
-                document.getElementById('current-path').textContent = currentDirectory;
-                displayContent(directory);
+            if (currentDirectory === '~') {
+                if (rootDirs.includes(directory)) {
+                    currentDirectory = `~/${directory}`;
+                    document.getElementById('current-path').textContent = currentDirectory;
+                    if (!content[directory]?.subdirs) {
+                        displayContent(directory);
+                    }
+                } else {
+                    addOutput("SYSTEM", `Directory not found: ${dir}", true);
+                }
             } else {
-                addOutput("SYSTEM", `Directory not found: ${dir}`, true);
+                const parent = currentDirectory.replace('~/', '').split('/').pop();
+                const subdirs = content[parent]?.subdirs || subDirMap[parent];
+                if (subdirs && subdirs.includes(directory)) {
+                    currentDirectory = `${currentDirectory}/${directory}`;
+                    document.getElementById('current-path').textContent = currentDirectory;
+                    displayContent(directory);
+                } else {
+                    addOutput("SYSTEM", `Directory not found: ${dir}", true);
+                }
             }
+
         }
 
         


### PR DESCRIPTION
## Summary
- add `subdirs` key to profile so its skills page is discoverable
- introduce `rootDirs` and `subDirMap` constants for navigation
- update `listDirectories` to show subdirectories or section content
- enhance `cd` to support nested directories and handle `..`
- extend autocomplete and command lookup to include subdirectories

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684a885fb1808330b1a5174089916166