### PR TITLE
Add `cd yoyaku` website shortcut

### DIFF
--- a/.web_aliases
+++ b/.web_aliases
@@ -2,13 +2,20 @@
 # commands that open specific websites.
 # These commands are hidden by default because the file name begins with a dot.
 
-# Override the built-in cd command to handle 'cd comtech'
+# Override the built-in cd command to handle custom shortcuts like
+# `cd comtech` and `cd yoyaku`
 cd() {
   if [ "$1" = "comtech" ]; then
     if command -v xdg-open >/dev/null 2>&1; then
       xdg-open "http://ksk432.com/ComTech.github.io/" >/dev/null 2>&1 &
     else
       open "http://ksk432.com/ComTech.github.io/"
+    fi
+  elif [ "$1" = "yoyaku" ]; then
+    if command -v xdg-open >/dev/null 2>&1; then
+      xdg-open "https://calendar.app.google/9ByBTDMnoJqSTMrt5" >/dev/null 2>&1 &
+    else
+      open "https://calendar.app.google/9ByBTDMnoJqSTMrt5"
     fi
   else
     builtin cd "$@"

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ To quickly open specific websites from the terminal, source the hidden
 `.web_aliases` file from your shell configuration. This enables:
 
 - `cd comtech` – opens <http://ksk432.com/ComTech.github.io/>
+- `cd yoyaku` – opens <https://calendar.app.google/9ByBTDMnoJqSTMrt5>
 - `mkomg` – opens <https://mkomg.lol>
 - `shinitai` – opens <https://shinitai.shop>
 


### PR DESCRIPTION
## Summary
- extend `.web_aliases` cd function so `cd yoyaku` opens the Google Calendar link
- document the new command in README

## Testing
- `pip install markdown`
- `python3 blog/generate.py`


------
https://chatgpt.com/codex/tasks/task_e_685cc23cab188330a40662d752ac7f02